### PR TITLE
make fixproc compliant with common newline conventions

### DIFF
--- a/fixProc.js
+++ b/fixProc.js
@@ -1,5 +1,5 @@
 // adapted from https://github.com/apatil/pemstrip
-var findProc = /Proc-Type: 4,ENCRYPTED\n\r?DEK-Info: AES-((?:128)|(?:192)|(?:256))-CBC,([0-9A-H]+)\n\r?\n\r?([0-9A-z\n\r\+\/\=]+)\n\r?/m
+var findProc = /Proc-Type: 4,ENCRYPTED[\n\r]+DEK-Info: AES-((?:128)|(?:192)|(?:256))-CBC,([0-9A-H]+)[\n\r]+([0-9A-z\n\r\+\/\=]+)[\n\r]+/m
 var startRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----/m
 var fullRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----([0-9A-z\n\r\+\/\=]+)-----END \1-----$/m
 var evp = require('evp_bytestokey')
@@ -10,11 +10,11 @@ module.exports = function (okey, password) {
   var decrypted
   if (!match) {
     var match2 = key.match(fullRegex)
-    decrypted = new Buffer(match2[2].replace(/\r?\n/g, ''), 'base64')
+    decrypted = new Buffer(match2[2].replace(/[\r\n]/g, ''), 'base64')
   } else {
     var suite = 'aes' + match[1]
     var iv = new Buffer(match[2], 'hex')
-    var cipherText = new Buffer(match[3].replace(/\r?\n/g, ''), 'base64')
+    var cipherText = new Buffer(match[3].replace(/[\r\n]/g, ''), 'base64')
     var cipherKey = evp(password, iv.slice(0, 8), parseInt(match[1], 10)).key
     var out = []
     var cipher = ciphers.createDecipheriv(suite, cipherKey, iv)

--- a/fixProc.js
+++ b/fixProc.js
@@ -1,7 +1,7 @@
 // adapted from https://github.com/apatil/pemstrip
 var findProc = /Proc-Type: 4,ENCRYPTED\n\r?DEK-Info: AES-((?:128)|(?:192)|(?:256))-CBC,([0-9A-H]+)\n\r?\n\r?([0-9A-z\n\r\+\/\=]+)\n\r?/m
 var startRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----\n/m
-var fullRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----\n\r?([0-9A-z\n\r\+\/\=]+)\n\r?-----END \1-----$/m
+var fullRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----([0-9A-z\n\r\+\/\=]+)-----END \1-----$/m
 var evp = require('evp_bytestokey')
 var ciphers = require('browserify-aes')
 module.exports = function (okey, password) {

--- a/fixProc.js
+++ b/fixProc.js
@@ -1,6 +1,6 @@
 // adapted from https://github.com/apatil/pemstrip
 var findProc = /Proc-Type: 4,ENCRYPTED\n\r?DEK-Info: AES-((?:128)|(?:192)|(?:256))-CBC,([0-9A-H]+)\n\r?\n\r?([0-9A-z\n\r\+\/\=]+)\n\r?/m
-var startRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----\n/m
+var startRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----/m
 var fullRegex = /^-----BEGIN ((?:.* KEY)|CERTIFICATE)-----([0-9A-z\n\r\+\/\=]+)-----END \1-----$/m
 var evp = require('evp_bytestokey')
 var ciphers = require('browserify-aes')

--- a/test/index.js
+++ b/test/index.js
@@ -80,6 +80,33 @@ function testIt (keys) {
   })
 }
 
+function testEOL (keys) {
+  var publicKey = keys.public.toString()
+  var newLineRegex = /\r?\n/g
+  var genPrivate = function (replace) {
+    if (keys.private.key) {
+      return { key: keys.private.key.toString().replace(newLineRegex, replace), passphrase: keys.private.passphrase }
+    } else {
+      return keys.private.toString().replace(newLineRegex, replace)
+    }
+  }
+  var testN = {
+    private: genPrivate('\n'),
+    public: publicKey.replace(newLineRegex, '\n')
+  }
+  testIt(testN)
+  var testR = {
+    private: genPrivate('\r'),
+    public: publicKey.replace(newLineRegex, '\r')
+  }
+  testIt(testR)
+  var testRN = {
+    private: genPrivate('\r\n'),
+    public: publicKey.replace(newLineRegex, '\r\n')
+  }
+  testIt(testRN)
+}
+
 testIt(dsa)
 testIt(dsa2)
 testIt(rsa1024)
@@ -94,3 +121,18 @@ testIt(rsapass2)
 testIt(pass1024)
 testIt(pass1024)
 testIt(cert)
+
+testEOL(dsa)
+testEOL(dsa2)
+testEOL(rsa1024)
+testEOL(ec)
+testEOL(rsa2028)
+testEOL(nonrsa1024)
+testEOL(ecpass)
+testEOL(dsapass)
+testEOL(dsapass2)
+testEOL(rsapass)
+testEOL(rsapass2)
+testEOL(pass1024)
+testEOL(pass1024)
+testEOL(cert)


### PR DESCRIPTION
I found that the regexes in fixproc.js weren't matching against valid certificates because of the newline convention that was used when generating them.

I believe that the parser should ignore the newline conventions based on the wording in [rfc7468](https://tools.ietf.org/html/rfc7468)

>  Furthermore, parsers SHOULD ignore whitespace and other non-
>    base64 characters and MUST handle different newline conventions.

I've added tests as per #13 (perhaps messy, but they ensure that someone doesn't accidentally change test file line endings)