### PR TITLE
update asn1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "asn1.js": "^4.0.0",
+    "asn1.js": "^5.2.0",
     "browserify-aes": "^1.0.0",
     "create-hash": "^1.1.0",
     "evp_bytestokey": "^1.0.0",


### PR DESCRIPTION
Should fix #23 also it fix Rollup build of browserify-crypto

Tests are passed

I didn't see any breaking change from 4 to 5 version so I assume it should be OK
