### PR TITLE
Improving published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "5.1.4",
   "description": "utility library for parsing asn1 files for use with browserify-sign.",
   "main": "index.js",
+  "files": [
+    "asn1.js",
+    "aesid.json",
+    "certificate.js",
+    "fixProc.js",
+    "index.js"
+  ],
   "scripts": {
     "unit": "node ./test",
     "standard": "standard",


### PR DESCRIPTION
At the moment parse-asn1 is published with the test directory along with a load of other files in the base directory. I don't believe these are needed and just slow down npm/yarn fetching the package.