### PR TITLE
Remove 'create-hash' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "asn1.js": "^4.0.0",
     "browserify-aes": "^1.0.0",
-    "create-hash": "^1.1.0",
     "evp_bytestokey": "^1.0.0",
     "pbkdf2": "^3.0.3",
     "safe-buffer": "^5.1.1"


### PR DESCRIPTION
Doesn't seems to be used anymore.