### PR TITLE
fix: pbkdf2 critical vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"browserify-aes": "^1.2.0",
 		"evp_bytestokey": "^1.0.3",
 		"hash-base": "~3.0",
-		"pbkdf2": "^3.1.2",
+		"pbkdf2": "^3.1.3",
 		"safe-buffer": "^5.2.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2025-6545

- update version pbkdf2 3.1.2 => 3.1.3
